### PR TITLE
Refactor: Do not use plugin to handle permissions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,6 @@ android {
 repositories { maven { url 'https://jitpack.io' } }
 
 dependencies {
-    implementation 'com.github.ankidroid:Anki-Android:api-v1.1.0'
+    implementation 'com.github.ankidroid:Anki-Android:v2.17.4'
 }
 

--- a/android/src/main/kotlin/com/aaalkoud/flutter_ankidroid/FlutterAnkidroidPlugin.kt
+++ b/android/src/main/kotlin/com/aaalkoud/flutter_ankidroid/FlutterAnkidroidPlugin.kt
@@ -15,6 +15,8 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
+
+
 /** FlutterAnkidroidPlugin */
 class FlutterAnkidroidPlugin: FlutterPlugin, MethodCallHandler {
   
@@ -80,11 +82,13 @@ class FlutterAnkidroidPlugin: FlutterPlugin, MethodCallHandler {
       "findDuplicateNotesWithKey" -> {
         val mid = call.argument<Long>("mid")!!
         val key = call.argument<String>("key")!!
-        val dupes = api.findDuplicateNotes(mid, key).map {hashMapOf(
-          "id" to it.id,
-          "fields" to it.fields.toList(),
-          "tags" to it.tags.toList()
-        )}
+        val dupes = api.findDuplicateNotes(mid, key).map {
+          hashMapOf(
+            "id" to it!!.getId(),
+            "fields" to it!!.getFields().toList(),
+            "tags" to it!!.getTags().toList()
+          )
+        }
 
         result.success(dupes)
       }
@@ -95,15 +99,15 @@ class FlutterAnkidroidPlugin: FlutterPlugin, MethodCallHandler {
         val dupes = api.findDuplicateNotes(mid, keys)
 
         val list = mutableListOf<List<Map<String, Any>>>()
-        for (i in 0 until dupes.size()) {
-          val innerList = dupes.valueAt(i)
+        for (i in 0 until dupes!!.size()) {
+          val innerList = dupes!!.valueAt(i)
 
           if (innerList != null) {
 
             list.add(innerList.map {hashMapOf(
-              "id" to it.id,
-              "fields" to it.fields.toList(),
-              "tags" to it.tags.toList()
+              "id" to it!!.getId(),
+              "fields" to it!!.getFields().toList(),
+              "tags" to it!!.getTags().toList()
             )})
 
           } else {
@@ -139,9 +143,9 @@ class FlutterAnkidroidPlugin: FlutterPlugin, MethodCallHandler {
         val note = api.getNote(noteId)
 
         result.success(hashMapOf(
-          "id" to note.id,
-          "fields" to note.fields.toList(),
-          "tags" to note.tags.toList()
+          "id" to note!!.getId(),
+          "fields" to note!!.getFields().toList(),
+          "tags" to note!!.getTags().toList()
         ))
       }
 
@@ -182,7 +186,7 @@ class FlutterAnkidroidPlugin: FlutterPlugin, MethodCallHandler {
       "getFieldList" -> {
         val modelId = call.argument<Long>("modelId")!!
 
-        result.success(api.getFieldList(modelId).toList())
+        result.success(api.getFieldList(modelId)!!.toList())
       }
 
       "modelList" -> result.success(api.modelList)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.20'
     repositories {
         google()
         mavenCentral()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,26 +73,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
-  request_permission:
-    dependency: transitive
-    description:
-      name: request_permission
-      sha256: f058e75a3ff29a6f5d5ed1042673d7d4d7e5abcda12256675cf88d095dfa84f6
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.4"
+    version: "1.11.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -122,14 +114,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=3.16.9"
+  dart: ">=3.2.0-0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -61,14 +61,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -81,18 +73,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   request_permission:
     dependency: transitive
     description:
@@ -130,6 +122,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
 sdks:
-  dart: ">=3.0.5 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
+  flutter: ">=3.16.9"

--- a/lib/flutter_ankidroid.dart
+++ b/lib/flutter_ankidroid.dart
@@ -18,10 +18,12 @@ class Ankidroid {
   /// If you hot restart your app, the isolate won't be killed, and vscode
   /// will show another isolate in your call stack. not that big of a deal.
   /// Btw, if anyone knows how to give the isolate a name please help
+  /// This is an open issue in the flutter_isolate package
+  /// https://github.com/rmawatson/flutter_isolate/issues/108
   static Future<Ankidroid> createAnkiIsolate() async {
     WidgetsFlutterBinding.ensureInitialized();
     
-    await askForPermission();
+    //await askForPermission();
 
     final rPort = ReceivePort();
     final isolate = await FlutterIsolate.spawn(_isolateFunction, rPort.sendPort);

--- a/lib/flutter_ankidroid.dart
+++ b/lib/flutter_ankidroid.dart
@@ -22,8 +22,6 @@ class Ankidroid {
   /// https://github.com/rmawatson/flutter_isolate/issues/108
   static Future<Ankidroid> createAnkiIsolate() async {
     WidgetsFlutterBinding.ensureInitialized();
-    
-    //await askForPermission();
 
     final rPort = ReceivePort();
     final isolate = await FlutterIsolate.spawn(_isolateFunction, rPort.sendPort);
@@ -32,6 +30,10 @@ class Ankidroid {
     return Ankidroid._(isolate, ankiPort);
   }
 
+  /// Ask for permission to communicate with ankidroid
+  /// This opens a dialog that the user needs to agree.
+  /// 
+  /// Note: this needs to be called before trying to communicate with ankidroid.
   static Future<void> askForPermission() async {
     final perms = RequestPermission.instace;
     if (!await perms.hasAndroidPermission('com.ichi2.anki.permission.READ_WRITE_DATABASE')) {

--- a/lib/flutter_ankidroid.dart
+++ b/lib/flutter_ankidroid.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:async/async.dart';
 import 'package:flutter_isolate/flutter_isolate.dart';
-import 'package:request_permission/request_permission.dart';
 
 import 'util/future_result.dart';
 export 'util/note_info.dart' show NoteInfo;
@@ -39,11 +38,13 @@ class Ankidroid {
   /// 
   /// Note: this needs to be called before trying to use any functions of an
   /// ankidroid isolate.
-  static Future<void> askForPermission() async {
-    final perms = RequestPermission.instace;
-    if (!await perms.hasAndroidPermission('com.ichi2.anki.permission.READ_WRITE_DATABASE')) {
-      await perms.requestAndroidPermission('com.ichi2.anki.permission.READ_WRITE_DATABASE');
-    }
+  static Future<bool> askForPermission() async {
+
+    const m = MethodChannel("flutter_ankidroid");
+    bool ret = await m.invokeMethod("requestPremission");
+    
+    return ret;
+
   }
 
   void killIsolate() => _isolate.kill();

--- a/lib/flutter_ankidroid.dart
+++ b/lib/flutter_ankidroid.dart
@@ -17,7 +17,11 @@ class Ankidroid {
 
   /// If you hot restart your app, the isolate won't be killed, and vscode
   /// will show another isolate in your call stack. not that big of a deal.
-  /// Btw, if anyone knows how to give the isolate a name please help
+  ///  
+  /// Note: `askForPermission` needs to be called before trying to use any
+  /// functions of this isolate.
+  /// 
+  /// Dev note: Btw, if anyone knows how to give the isolate a name please help
   /// This is an open issue in the flutter_isolate package
   /// https://github.com/rmawatson/flutter_isolate/issues/108
   static Future<Ankidroid> createAnkiIsolate() async {
@@ -33,7 +37,8 @@ class Ankidroid {
   /// Ask for permission to communicate with ankidroid
   /// This opens a dialog that the user needs to agree.
   /// 
-  /// Note: this needs to be called before trying to communicate with ankidroid.
+  /// Note: this needs to be called before trying to use any functions of an
+  /// ankidroid isolate.
   static Future<void> askForPermission() async {
     final perms = RequestPermission.instace;
     if (!await perms.hasAndroidPermission('com.ichi2.anki.permission.READ_WRITE_DATABASE')) {

--- a/lib/util/note_info.dart
+++ b/lib/util/note_info.dart
@@ -1,13 +1,19 @@
 /// You can use this with functions that return Java NoteInfos or Lists of NoteInfos
 class NoteInfo {
+
   final int id;
+  
   final List<String> fields;
+  
   final List<String> tags;
+
 
   const NoteInfo(this.id, this.fields, this.tags);
   
   NoteInfo.from(Map<dynamic, dynamic> map) : 
-    id = map['id']! as int, fields = List<String>.from(map['fields']!), tags = List<String>.from(map['tags']!);
+    id = map['id']! as int,
+    fields = List<String>.from(map['fields']!),
+    tags = List<String>.from(map['tags']!);
   
   static List<NoteInfo> fromList(List<Map<dynamic, dynamic>> list) {
     return list.map((e) => NoteInfo.from(e)).toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   flutter_isolate: ^2.0.4
   async: ^2.11.0
-  request_permission: ^2.1.4
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
This PR removes the dependency `request_permission`. This is necessary as that plugin breaks the `file_picker` plugin.
Instead of depending on that plugin this PR implements a native dialog and waits for the user's choice. Therefore, the method `requestPermission` now returns a bool that corresponds to the user's choice.

info:
This PR also includes the changes of my other PR